### PR TITLE
Fix: Start the correct python file in the start batch file.

### DIFF
--- a/Start Mumble Bot.bat
+++ b/Start Mumble Bot.bat
@@ -20,7 +20,7 @@ for /f "delims=" %%V in ('where py') do @set pythonpath=%%V
 for /f "delims=" %%V in ('%pythonpath% --version') do @set pythonversion=%%V 
 echo Using %pythonversion% at %pythonpath%
 
-%pythonpath% "bot.py"
+%pythonpath% "DalraeMumbleBot.py"
 
 echo Process Terminated.
 pause


### PR DESCRIPTION
As the title says, fixing the start batch file to use the correct name of the script